### PR TITLE
RPC monitor on debugbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This package provides an easy way of connecting to
 ## Usage
 
 ```php
-$client = RPC::get('service_one', '1.0');
+$client = ZeroRPC::get('service_one', '1.0');
 $response = $client->service_function($param1, $param2);
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ $client = RPC::get('service_one', '1.0');
 $response = $client->service_function($param1, $param2);
 ```
 
-## Configurations
+## Connection monitor
 
-### debugbar_rpc_monitor
-Monitor RPC connections on Debugbar panels.
-Make sure you installed [Debugbar](https://github.com/barryvdh/laravel-debugbar) if you want to enable it.
-
-Default: `false`
+If you installed [Debugbar](https://github.com/barryvdh/laravel-debugbar) the RPC connection information shows on Debugbar panels.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ This package provides an easy way of connecting to
 $client = RPC::get('service_one', '1.0');
 $response = $client->service_function($param1, $param2);
 ```
+
+## Configurations
+
+### debugbar_rpc_monitor
+Monitor RPC connections on Debugbar panels.
+Make sure you installed [Debugbar](https://github.com/barryvdh/laravel-debugbar) if you want to enable it.
+
+Default: `false`

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
             "email": "engineering@juwai.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:juwai/zerorpc-php.git"
+        }
+    ],
     "require": {
         "php": ">=5.4.0",
         "laravel/framework": ">=5.1.0",

--- a/config/zerorpc.php
+++ b/config/zerorpc.php
@@ -12,4 +12,5 @@ return [
         'access_key' => env('RPC_SERVICE_TWO_ACCESS_KEY'),
         'default'    => env('RPC_SERVICE_TWO_VERSION'),
     ],
+    'debugbar_rpc_monitor' => env('RPC_DEBUGBAR_RPC_MONITOR', false),
 ];

--- a/config/zerorpc.php
+++ b/config/zerorpc.php
@@ -12,5 +12,4 @@ return [
         'access_key' => env('RPC_SERVICE_TWO_ACCESS_KEY'),
         'default'    => env('RPC_SERVICE_TWO_VERSION'),
     ],
-    'debugbar_rpc_monitor' => env('RPC_DEBUGBAR_RPC_MONITOR', false),
 ];

--- a/src/Providers/ZeroRPCContextProvider.php
+++ b/src/Providers/ZeroRPCContextProvider.php
@@ -46,7 +46,7 @@ class ZeroRPCContextProvider extends ServiceProvider
                 $middleware->beforeSendRequest()
             );
 
-            if (config('zerorpc.debugbar_rpc_monitor') === true) {
+            if ($this->app->getProvider('Barryvdh\Debugbar\ServiceProvider')) {
                 $context->registerHook(
                     'before_send_request',
                     $this->debugbarStartMeasure()

--- a/src/Providers/ZeroRPCContextProvider.php
+++ b/src/Providers/ZeroRPCContextProvider.php
@@ -46,6 +46,17 @@ class ZeroRPCContextProvider extends ServiceProvider
                 $middleware->beforeSendRequest()
             );
 
+            if (config('zerorpc.debugbar_rpc_monitor') === true) {
+                $context->registerHook(
+                    'before_send_request',
+                    $this->debugbarStartMeasure()
+                );
+                $context->registerHook(
+                    'after_response',
+                    $this->debugbarStopMeasure()
+                );
+            }
+
             return $context;
         });
     }
@@ -58,5 +69,33 @@ class ZeroRPCContextProvider extends ServiceProvider
     public function provides()
     {
         return ['Juwai\LaravelZeroRPC\Context'];
+    }
+
+    /**
+     * Debugbar start measure callback.
+     *
+     * @return function
+     */
+    private function debugbarStartMeasure()
+    {
+        return function ($event, $client) {
+            start_measure(
+                $event->header['message_id'],
+                'RPC: ' . $event->name
+            );
+            debug('RPC: ' . $event->name . ' ' . json_encode($event->args));
+        };
+    }
+
+    /**
+     * Debugbar stop measure callback.
+     *
+     * @return function
+     */
+    private function debugbarStopMeasure()
+    {
+        return function ($event, $client) {
+            stop_measure($event->header['response_to']);
+        };
     }
 }


### PR DESCRIPTION
## Summary of changes

- Show RPC connection information on Debugbar.
  - Show RPC endpoint parameters in Messages tab.
  - Show RPC connection query times in Timeline tab.

I force pushed the commits while the [previous PR](https://github.com/juwai/laravel-zerorpc/pull/3) was closed, so I have to create a new PR instead. Sorry @tjoelsson @xinningsu 