### PR TITLE
PLAT-870 Failed with KeyError (update version for laravel-zerorpc)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "0rpc/zerorpc-php": "1.2.*"
+        "0rpc/zerorpc-php": ">=1.2.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary of changes

the version of zerorpc should be higher than 1.2.5

## How to Test
1) cd laravel-zerorpc
2) composer install

/fyi: @mark-juwai , @zhangjustin : Please review.