### PR TITLE
Lazy connect

### DIFF
--- a/src/Services/LazyClientWrapper.php
+++ b/src/Services/LazyClientWrapper.php
@@ -26,6 +26,18 @@ class LazyClientWrapper
 
     public function __call($name, $arguments)
     {
+        $this->_createClientIfNotExist();
+        return call_user_func_array([$this->_client, $name], $arguments);
+    }
+
+    public function async($name, array $args, &$response)
+    {
+        $this->_createClientIfNotExist();
+        return $this->_client->async($name, $args, $response);
+    }
+
+    private function _createClientIfNotExist()
+    {
         if (is_null($this->_client)) {
             $this->_client = new Client(
                 $this->_serviceName,
@@ -39,7 +51,5 @@ class LazyClientWrapper
 
             $this->_client->setTimeout($this->_timeout);
         }
-
-        return call_user_func_array([$this->_client, $name], $arguments);
     }
 }

--- a/src/Services/LazyClientWrapper.php
+++ b/src/Services/LazyClientWrapper.php
@@ -1,0 +1,43 @@
+<?php
+namespace Juwai\LaravelZeroRPC\Services;
+
+/*
+ * When a client object is created, the PHP client will immediately connect
+ * to the endpoint. This wrapper avoids connecting until there is an actual
+ * function call.
+ */
+class LazyClientWrapper
+{
+    private $_client = null;
+    private $_serviceName;
+    private $_version;
+    private $_context;
+    private $_timeout;
+
+    public function __construct($serviceName, $version, $context, $timeout)
+    {
+        $this->_serviceName = $serviceName;
+        $this->_version = $version;
+        $this->_context = $context;
+        $this->_timeout = $timeout;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if (is_null($this->_client)) {
+            $this->_client = new Client(
+                $this->_serviceName,
+                $this->_version,
+                $this->_context
+            );
+
+            if ($this->_timeout == null) {
+                $this->_timeout = env('DEFAULT_RPC_TIMEOUT', 1000);
+            }
+
+            $this->_client->setTimeout($this->_timeout);
+        }
+
+        return call_user_func_array([$this->_client, $name], $arguments);
+    }
+}

--- a/src/Services/LazyClientWrapper.php
+++ b/src/Services/LazyClientWrapper.php
@@ -1,7 +1,9 @@
 <?php
 namespace Juwai\LaravelZeroRPC\Services;
 
-/*
+use ZeroRPC\Client;
+
+/**
  * When a client object is created, the PHP client will immediately connect
  * to the endpoint. This wrapper avoids connecting until there is an actual
  * function call.

--- a/src/Services/ZeroRPCFactory.php
+++ b/src/Services/ZeroRPCFactory.php
@@ -1,8 +1,6 @@
 <?php
 namespace Juwai\LaravelZeroRPC\Services;
 
-use Log;
-use ZeroRPC\Client;
 use Juwai\LaravelZeroRPC\Services\LazyClientWrapper;
 
 class ZeroRPCFactory

--- a/src/Services/ZeroRPCFactory.php
+++ b/src/Services/ZeroRPCFactory.php
@@ -21,11 +21,13 @@ class ZeroRPCFactory
         }
 
         $context = $context ?: $this->context;
-        $client = new Client($serviceName, $version, $context);
-        if ($timeout == null) {
-            $timeout = env('DEFAULT_RPC_TIMEOUT', 1000);
-        }
-        $client->setTimeout($timeout);
+
+        $client = new _LazyClientWrapper(
+            $serviceName,
+            $version,
+            $context,
+            $timeout
+        );
 
         self::$_clients[$key] = $client;
 
@@ -36,5 +38,46 @@ class ZeroRPCFactory
     {
         $key = $serviceName . $version . $timeout;
         unset(self::$_clients[$key]);
+    }
+}
+
+/*
+ * When a client object is created, the PHP client will immediately connect
+ * to the endpoint. This wrapper avoids connecting until there is an actual
+ * function call.
+ */
+class _LazyClientWrapper
+{
+    private $_client = null;
+    private $_serviceName;
+    private $_version;
+    private $_context;
+    private $_timeout;
+
+    public function __construct($serviceName, $version, $context, $timeout)
+    {
+        $this->_serviceName = $serviceName;
+        $this->_version = $version;
+        $this->_context = $context;
+        $this->_timeout = $timeout;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        if (is_null($this->_client)) {
+            $this->_client = new Client(
+                $this->_serviceName,
+                $this->_version,
+                $this->_context
+            );
+
+            if ($this->_timeout == null) {
+                $this->_timeout = env('DEFAULT_RPC_TIMEOUT', 1000);
+            }
+
+            $this->_client->setTimeout($this->_timeout);
+        }
+
+        return call_user_func_array([$this->_client, $name], $arguments);
     }
 }

--- a/src/Services/ZeroRPCFactory.php
+++ b/src/Services/ZeroRPCFactory.php
@@ -3,6 +3,7 @@ namespace Juwai\LaravelZeroRPC\Services;
 
 use Log;
 use ZeroRPC\Client;
+use Juwai\LaravelZeroRPC\Services\LazyClientWrapper;
 
 class ZeroRPCFactory
 {
@@ -22,7 +23,7 @@ class ZeroRPCFactory
 
         $context = $context ?: $this->context;
 
-        $client = new _LazyClientWrapper(
+        $client = new LazyClientWrapper(
             $serviceName,
             $version,
             $context,
@@ -38,46 +39,5 @@ class ZeroRPCFactory
     {
         $key = $serviceName . $version . $timeout;
         unset(self::$_clients[$key]);
-    }
-}
-
-/*
- * When a client object is created, the PHP client will immediately connect
- * to the endpoint. This wrapper avoids connecting until there is an actual
- * function call.
- */
-class _LazyClientWrapper
-{
-    private $_client = null;
-    private $_serviceName;
-    private $_version;
-    private $_context;
-    private $_timeout;
-
-    public function __construct($serviceName, $version, $context, $timeout)
-    {
-        $this->_serviceName = $serviceName;
-        $this->_version = $version;
-        $this->_context = $context;
-        $this->_timeout = $timeout;
-    }
-
-    public function __call(string $name, array $arguments)
-    {
-        if (is_null($this->_client)) {
-            $this->_client = new Client(
-                $this->_serviceName,
-                $this->_version,
-                $this->_context
-            );
-
-            if ($this->_timeout == null) {
-                $this->_timeout = env('DEFAULT_RPC_TIMEOUT', 1000);
-            }
-
-            $this->_client->setTimeout($this->_timeout);
-        }
-
-        return call_user_func_array([$this->_client, $name], $arguments);
     }
 }


### PR DESCRIPTION
## Summary of changes

Add a wrapper around the client object to stop connecting to service until a function is called

## How to Test

Create some clients:

```php
ZeroRPC::get('service_1', '1.0');
ZeroRPC::get('service_2', '1.0');
ZeroRPC::get('service_3', '1.0');
```

Check open connections with netstat:

```bash
$ netstat -nutw
```

There should be no connection opened to the services